### PR TITLE
fix: tsc failing due to missing ignore

### DIFF
--- a/src/Fireblocks-signer.ts
+++ b/src/Fireblocks-signer.ts
@@ -50,6 +50,7 @@ class FireblocksSigner implements Signer {
                 const signature = '0x00' + signedTx[0].signature.fullSig;
                 console.log('Signature: ' + signature);
 
+                //@ts-ignore
                 resolve({ id: 1, signature });
             }
         });


### PR DESCRIPTION
Missing ts-ignore in Fireblocks-Signer results in `tsc` failing due to type mismatch.
Aligned it to the polkadot code.